### PR TITLE
Using KMS materials cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
 ## 0.1.0
   - Plugin created with the logstash plugin generator
+
+## 5.0.0
+  - Support KMS Caching
+

--- a/logstash-codec-kms.gemspec
+++ b/logstash-codec-kms.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-codec-kms'
-  s.version       = '0.1.0'
+  s.version       = '5.0.0'
   s.licenses      = ['BSD-3-Clause']
   s.summary       = "Codec for decrypting and encrypting messages using AWS KMS in Logstash"
   s.description   = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-json'
   s.add_development_dependency 'logstash-devutils'
 
-  s.requirements << "jar 'com.amazonaws:aws-encryption-sdk-java', '0.0.1'"
+  s.requirements << "jar 'com.amazonaws:aws-encryption-sdk-java', '1.3.1'"
   s.requirements << "jar 'com.amazonaws:aws-java-sdk', '1.11.118'"
   s.add_runtime_dependency 'jar-dependencies'
 end


### PR DESCRIPTION
Bumping aws encryption SDK version to utilize KMS key caching.

Bumping version of this plugin to 5.0.0 to denote that this is a logstash-5 compatible plugin.